### PR TITLE
Add rate limiter to POST /transactions/deposit/:id?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,5 @@ bot_sessions
 
 history.txt
 test_setup.sh
+
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.stickyScroll.enabled": true,
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## [1.0.0] - 2024-04-01
+
+### Added
+- CHANGELOG.md.
+- Deposit rate limiter (1 request with same `tracking_number` every 10 seconds).
+
+### Changed
+- Added .vscode/settings.json to .gitignore

--- a/README.md
+++ b/README.md
@@ -451,6 +451,27 @@ Estado de transferencia de fichas
 }
 ```
 
+## Load Testing
+
+### Ddosify
+
+Correr contenedor de ddosify con
+```bash
+$ docker run -it --rm --add-host host.docker.internal:host-gateway ddosify/ddosify
+```
+
+Luego obtener un token de acceso y correr el siguiente comando en el contenedor
+```bash
+$ ddosify -t 'http://host.docker.internal:8080/app/v1/endpoint \
+-m POST \
+-b '{"json": "data"}' \
+-h 'Content-Type: application/json' \
+-h "Authorization: Bearer $ACCESS_TOKEN" \
+-h 'User-Agent: curl/7.81.0' \
+-n <request_count>
+-d <test_duration>
+```
+
 ## Despliegue
 
 - `npx prisma migrate deploy` Para levantar la base de datos.
@@ -458,7 +479,6 @@ Estado de transferencia de fichas
 
 ## TODO
 
-- Instanciar servicios en lugar de usar metodos estaticos
 - Cambiar contraseña (no funciona en el casino, vamos por este lado)
   - Endpoint https://agent.casinomex.vip/api/users/5941/change-password/
   - Body: `{ new_password:	string }`
@@ -468,16 +488,14 @@ Estado de transferencia de fichas
 
 - [Bot Whatsapp](https://bot-whatsapp.netlify.app/) ✅
   + [Diagrama Flujo](https://www.figma.com/file/rtxhrNqQxdEdYzOfPl1mRc/Whatsapp-Bot?type=whiteboard&node-id=0%3A1&t=5ACojRhp99vrh24S-1)
-- Cambiar IDs incrementales por UUIDs en producción
 - Configurar bbdd distintas para dev y prod
 - Chequear si agent existe en la bbdd en `seed.ts`
 - Subir la duracion del refresh token a 24 horas
-- Actualizar tabla depositos en panel agente
-- Hacer endpoint de cancelar deposito para jugador
 - Tener en cuenta que pasa si el casino devuelve 200 a una transfer de fichas pero la transferencia no pasa
 - Balance Alquimia en panel agente
-
 - Dar al agente posibilidad de modificar un deposito y llamar `.confirmDeposit`
+- Setear ancho maximo en columnas ID en panel agente
+- Agregar boton para copiar ID en panel agente
 
 ### Fichas insuficientes
 

--- a/__tests__/transactions.test.ts
+++ b/__tests__/transactions.test.ts
@@ -97,7 +97,6 @@ describe("[UNIT] => TRANSACTIONS", () => {
         .set("Authorization", `Bearer ${tokens[1].access}`)
         .set("User-Agent", USER_AGENT);
 
-      console.log("CONFIRMATION RESULT", response.body);
       expect(response.status).toBe(OK);
       expect(response.body.data.deposit).toBeDefined();
     });

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "passport-jwt": "^4.0.1",
     "pino-pretty": "^9.4.1",
     "prisma": "^5.9.1",
+    "rate-limiter-flexible": "^5.0.0",
     "readline-sync": "^1.4.10",
     "rimraf": "^3.0.2",
     "rollup": "^4.12.0",

--- a/prisma/migrations/20240401132020_add_on_delete_cascade_to_player/migration.sql
+++ b/prisma/migrations/20240401132020_add_on_delete_cascade_to_player/migration.sql
@@ -1,0 +1,32 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `owner_id` on the `BANK_ACCOUNTS` table. The data in that column could be lost. The data in that column will be cast from `Int` to `UnsignedInt`.
+
+*/
+-- DropForeignKey
+ALTER TABLE `BANK_ACCOUNTS` DROP FOREIGN KEY `BANK_ACCOUNTS_player_id_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `DEPOSITS` DROP FOREIGN KEY `DEPOSITS_player_id_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `PAYMENTS` DROP FOREIGN KEY `PAYMENTS_player_id_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `TOKENS` DROP FOREIGN KEY `TOKENS_player_id_fkey`;
+
+-- AlterTable
+ALTER TABLE `BANK_ACCOUNTS` MODIFY `owner_id` INTEGER UNSIGNED NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE `PAYMENTS` ADD CONSTRAINT `PAYMENTS_player_id_fkey` FOREIGN KEY (`player_id`) REFERENCES `PLAYERS`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `BANK_ACCOUNTS` ADD CONSTRAINT `BANK_ACCOUNTS_player_id_fkey` FOREIGN KEY (`player_id`) REFERENCES `PLAYERS`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `DEPOSITS` ADD CONSTRAINT `DEPOSITS_player_id_fkey` FOREIGN KEY (`player_id`) REFERENCES `PLAYERS`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `TOKENS` ADD CONSTRAINT `TOKENS_player_id_fkey` FOREIGN KEY (`player_id`) REFERENCES `PLAYERS`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,7 +52,7 @@ model Player {
   date_of_birth     DateTime?
   movile_number     String?       @db.VarChar(50)
   country           String?       @db.VarChar(50)
-  BankAccounts      BankAccount[]  
+  BankAccounts      BankAccount[]
   balance_currency  String       @db.VarChar(10) @default("MXN")
   status            String?       @db.VarChar(20) @default("ACTIVO")
   Payments          Payment[]       
@@ -68,7 +68,7 @@ model Player {
 model Payment {
   id                String        @id @default(uuid())
   player_id         String           
-  Player            Player        @relation(fields: [player_id], references: [id])
+  Player            Player        @relation(fields: [player_id], references: [id], onDelete: Cascade)
   amount            Float
   paid              DateTime?     
   bank_account      String           
@@ -84,7 +84,7 @@ model BankAccount {
   id                String        @id @default(uuid())
   owner             String        // Nombre del beneficiario
   owner_id          Int           @db.UnsignedInt // DNI
-  Player            Player        @relation(fields: [player_id], references: [id])
+  Player            Player        @relation(fields: [player_id], references: [id], onDelete: Cascade)
   player_id         String        // ID de Player
   bankName          String        // Nombre del banco
   bankNumber        String        @unique // CBU
@@ -99,7 +99,7 @@ model BankAccount {
 model Deposit {
   id                String        @id @default(uuid())
   player_id         String           
-  Player            Player        @relation(fields: [player_id], references: [id])
+  Player            Player        @relation(fields: [player_id], references: [id], onDelete: Cascade)
   currency          String        @default("MXN")
   dirty             Boolean       @default(true)
   status            String
@@ -116,7 +116,7 @@ model Token {
   invalid           Boolean       @default(false)
   next              String?       
   player_id         String           
-  player            Player        @relation(fields: [player_id], references: [id])
+  player            Player        @relation(fields: [player_id], references: [id], onDelete: Cascade)
   user_agent        String?       @db.VarChar(256)
   created_at        DateTime      @default(now())
   updated_at        DateTime      @updatedAt 

--- a/src/config/errors.ts
+++ b/src/config/errors.ts
@@ -67,4 +67,9 @@ export const ERR: { [key: string]: ErrorData } = {
     code: "transaction_log",
     description: "Error al loguear transaccion",
   },
+  TOO_MANY_REQUESTS: {
+    status: 429,
+    code: "too_many_requests",
+    description: "Demasiadas solicitudes",
+  },
 };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -80,6 +80,11 @@ const CONFIG = {
       /** Deleted by agent */
       DELETED: "deleted",
     },
+    ENVIRONMENTS: {
+      TEST: "test",
+      DEV: "dev",
+      PRODUCTION: "production",
+    },
   },
 } as const;
 

--- a/src/middlewares/rate-limiters/deposit.ts
+++ b/src/middlewares/rate-limiters/deposit.ts
@@ -1,0 +1,24 @@
+import { RateLimiterMemory } from "rate-limiter-flexible";
+import { DepositRequest } from "@/types/request/transfers";
+import { CustomError } from "@/middlewares/errorHandler";
+import { ERR } from "@/config/errors";
+import CONFIG from "@/config";
+
+const rateLimiter = new RateLimiterMemory({
+  points: CONFIG.APP.ENV === CONFIG.SD.ENVIRONMENTS.TEST ? 10 : 1,
+  duration: 10,
+});
+
+/**
+ * Limit the amount of requests with the same tracking_number to 1 every
+ * 10 seconds
+ */
+export const depositRateLimiter = (req: Req, res: Res, next: NextFn) => {
+  rateLimiter
+    .consume((req.body as DepositRequest).tracking_number, 1)
+    .then(() => next())
+    .catch((err): void => {
+      res.header("Retry-After", `${err.msBeforeNext / 1000}`);
+      next(new CustomError(ERR.TOO_MANY_REQUESTS));
+    });
+};

--- a/src/routes/transactions.router.ts
+++ b/src/routes/transactions.router.ts
@@ -9,6 +9,7 @@ import {
   validateDepositRequest,
 } from "@/components/transactions/validators";
 import { AgentController } from "@/components/agent";
+import { depositRateLimiter } from "@/middlewares/rate-limiters/deposit";
 
 const transactionsRouter = Router();
 
@@ -16,12 +17,12 @@ transactionsRouter.use(
   passport.authenticate("jwt", { session: false, failWithError: true }),
 );
 transactionsRouter.use(requireUserRole);
-// TODO throttle by Tracking number
 transactionsRouter.post(
   "/deposit/:id?",
   validateDepositRequest(),
   checkExact(),
   throwIfBadRequest,
+  depositRateLimiter,
   TransactionsController.deposit,
 );
 transactionsRouter.get(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1501,14 +1501,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bot-whatsapp/bot@*":
-  version "0.1.38"
-  resolved "https://registry.yarnpkg.com/@bot-whatsapp/bot/-/bot-0.1.38.tgz#3c9a2a5a1f00f99710dd42fc037fd130d5f676bb"
-  integrity sha512-M1FDbsgkn+03zss3zen0w2BdQytOEcHLXAkJZP8qU6w22B1B6nOw0871o/LqKzIaiLS7paSEc/6rDr3reYl84g==
-  dependencies:
-    dotenv "^16.0.3"
-
-"@bot-whatsapp/bot@^0.1.38":
+"@bot-whatsapp/bot@*", "@bot-whatsapp/bot@^0.1.38":
   version "0.1.38"
   resolved "https://registry.yarnpkg.com/@bot-whatsapp/bot/-/bot-0.1.38.tgz#3c9a2a5a1f00f99710dd42fc037fd130d5f676bb"
   integrity sha512-M1FDbsgkn+03zss3zen0w2BdQytOEcHLXAkJZP8qU6w22B1B6nOw0871o/LqKzIaiLS7paSEc/6rDr3reYl84g==
@@ -4264,11 +4257,6 @@ core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
-
-core-util-is@~1.0.0:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
-  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cors@^2.8.3:
   version "2.8.5"
@@ -8237,6 +8225,11 @@ range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
+rate-limiter-flexible@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/rate-limiter-flexible/-/rate-limiter-flexible-5.0.0.tgz#e03de7eac7f8fe55f976b9f2eafc365739bb6cf8"
+  integrity sha512-ivCyLBwPtR5IRrz+aZnztVwX16ZK3iAjdlW21I/vjHq56at5Zb8eIefDzODg8R7hwPOHpBtb6Pj9Zdmn0nRb8g==
+
 raw-body@2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.2.tgz#99febd83b90e08975087e8f1f9419a149366b68a"
@@ -8990,22 +8983,10 @@ string.prototype.trimstart@^1.0.7:
 
 string_decoder@^1.1.1, string_decoder@^1.3.0:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
-string_decoder@^1.1.1:
-  version "1.3.0"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
-
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-  integrity sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
# Description

Agregué un rate limiter que limita el numero de requests con el mismo `tracking_number` a 1 cada 10 segundos.

Hay dependencias nuevas asi que al desplegar corré `yarn install`

Corré `npx prisma migrate deploy` y `npx prisma generate`. No hace falta resetear la bbdd.

También agregué un ON DELETE CASCADE a las entidades que están relacionadas al Player para que mariadb no se queje cuando queremos borrar jugadores