### PR TITLE
Improve db transaction usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.0.0] - 2024-08-12
+
+## Added
+- Rate limiter to `/bonus/:id/redeem`: 1 request every 10 seconds for the same `:id`.
+- "Dirty" column to Bonus table.
+
 ## [1.0.0] - 2024-08-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ Requiere rol| player
 Método      |`GET`
 Devuelve    |[`BonusRedemptionResult`](#bonusredemptionresult)
 Requiere rol| player
+Rate-limited|1 every 10 seconds for the same `:id`
 
 Transferencia de Fichas
 -----------------------
@@ -1105,6 +1106,55 @@ Respesta
 Sacar el valor del atributo `MontoPago` del elemento `Beneficiario`
 
 
+## Subagent
+
+### Create
+
+POST https://agent.casinomex.vip/api/pyramid/create/agent/
+
+Request
+```json
+{
+  "username":"testsubagent01",
+  "password":"1234",
+  "email":"",
+  "social_links":[
+    {
+      "link":"",
+     "social_type":"WA"
+    }
+  ],
+  "user_info":{
+    "mobile_number":"",
+    "first_name":"",
+    "last_name":""
+  },
+  "agent_info":{
+    "payments_percentage":50
+  }
+}
+```
+
+Response
+```json
+{
+  "username":"testsubagent01",
+  "password":"1234",
+  "email":"",
+  "social_links":[{
+      "link":"",
+      "social_type":"WA"
+  }],
+  "user_info": {
+    "mobile_number":"",
+    "first_name":"",
+    "last_name":""
+  },
+  "agent_info": {
+    "payments_percentage":50
+  }
+}
+```
 
 ## Password restoration checklist
 

--- a/__tests__/bonus.test.ts
+++ b/__tests__/bonus.test.ts
@@ -24,6 +24,7 @@ describe("[UNIT] => BONUS ROUTER", () => {
     player_id: "baz",
     status: BONUS_STATUS.ASSIGNED,
     coin_transfer_id: "bar",
+    dirty: false,
     created_at: new Date(),
     updated_at: new Date(),
   };

--- a/__tests__/player.test.ts
+++ b/__tests__/player.test.ts
@@ -370,6 +370,7 @@ describe("[UNIT] => PLAYERS ROUTER", () => {
       percentage: 100,
       status: BONUS_STATUS.ASSIGNED,
       coin_transfer_id: "eggs",
+      dirty: false,
       created_at: new Date(),
       updated_at: new Date(),
     };

--- a/prisma/migrations/20240812184307_add_dirty_column_to_bonus/migration.sql
+++ b/prisma/migrations/20240812184307_add_dirty_column_to_bonus/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `BONUS` ADD COLUMN `dirty` BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -209,6 +209,7 @@ model Bonus {
   amount                      Int
   coin_transfer_id            String        @unique
   CoinTransfer                CoinTransfer  @relation(fields: [coin_transfer_id], references: [id], onDelete: Cascade)
+  dirty                       Boolean       @default(false)
   created_at                  DateTime      @default(now())
   updated_at                  DateTime      @updatedAt 
   
@@ -219,7 +220,7 @@ model CoinTransfer {
   id                          String    @id @default(uuid())
   status                      String    @db.VarChar(32)
   player_balance_after        Float?
-  Bonus                       Bonus?
+  Bonus                       Bonus?    
   Deposit                     Deposit?
   Payment                     Payment?
   created_at                  DateTime  @default(now())

--- a/src/components/bonus/validators.ts
+++ b/src/components/bonus/validators.ts
@@ -11,6 +11,7 @@ export const isKeyOfBonus = (key: string): key is keyof Bonus => {
     player_id: "",
     status: "",
     coin_transfer_id: "",
+    dirty: false,
     Player: {
       id: "",
       panel_id: 0,

--- a/src/components/deposits/controller.ts
+++ b/src/components/deposits/controller.ts
@@ -78,7 +78,7 @@ export class DepositController {
       if (deposit.status === DEPOSIT_STATUS.VERIFIED) {
         coinTransfer = await useTransaction((tx) =>
           coinTransferServices.agentToPlayer(deposit!.coin_transfer_id, tx),
-        );
+        ).catch(() => undefined);
         bonus = await bonusServices.load(
           deposit.amount,
           deposit.Player.Bonus?.id,

--- a/src/components/deposits/controller.ts
+++ b/src/components/deposits/controller.ts
@@ -13,6 +13,7 @@ import { extractResourceSearchQueryParams } from "@/helpers/queryParams";
 import { hidePassword } from "@/utils/auth";
 import { DEPOSIT_STATUS } from "@/config";
 import { DepositResult } from "@/types/response/transfers";
+import { useTransaction } from "@/helpers/useTransaction";
 
 export class DepositController {
   static readonly index = async (req: Req, res: Res, next: NextFn) => {
@@ -75,8 +76,8 @@ export class DepositController {
       }
 
       if (deposit.status === DEPOSIT_STATUS.VERIFIED) {
-        coinTransfer = await coinTransferServices.agentToPlayer(
-          deposit.coin_transfer_id,
+        coinTransfer = await useTransaction((tx) =>
+          coinTransferServices.agentToPlayer(deposit!.coin_transfer_id, tx),
         );
         bonus = await bonusServices.load(
           deposit.amount,

--- a/src/components/deposits/services.ts
+++ b/src/components/deposits/services.ts
@@ -42,18 +42,21 @@ export class DepositServices extends ResourceService {
     deposit_id: string,
     request: DepositRequest,
   ) {
+    const deposit = await DepositsDAO._getById(deposit_id);
+    if (deposit?.status === DEPOSIT_STATUS.VERIFIED) return deposit;
+
     await DepositsDAO.authorizeUpdate(
       deposit_id,
       player,
       request.tracking_number,
     );
 
-    const deposit = await DepositsDAO.update({
+    const updated = await DepositsDAO.update({
       where: { id: deposit_id },
       data: request,
     });
 
-    return await this.verify(deposit);
+    return await this.verify(updated);
   }
 
   async setStatus(

--- a/src/db/bonus.ts
+++ b/src/db/bonus.ts
@@ -187,14 +187,7 @@ export class BonusDAO {
 
       if (bonus.Player.id !== user.id) throw new ForbiddenError("Unauthorized");
 
-      const balance = await playerServices.getBalance(
-        bonus.Player.id,
-        bonus.Player,
-      );
-      if (balance >= 10)
-        throw new ForbiddenError(
-          "El bono solo se puede canjear cuando el balance es menor que 10.",
-        );
+      if (bonus.dirty) throw new ForbiddenError("El bono está siendo canjeado");
 
       if (bonus.status === BONUS_STATUS.UNAVAILABLE)
         throw new ForbiddenError("Lo siento, tu bono ya no esta disponible.");
@@ -206,6 +199,15 @@ export class BonusDAO {
 
       if (bonus.status === BONUS_STATUS.ASSIGNED)
         throw new ForbiddenError("Has un deposito para acceder a tu bono.");
+
+      const balance = await playerServices.getBalance(
+        bonus.Player.id,
+        bonus.Player,
+      );
+      if (balance >= 10)
+        throw new ForbiddenError(
+          "El bono solo se puede canjear cuando el balance es menor que 10.",
+        );
 
       return bonus;
     });

--- a/src/db/deposits.ts
+++ b/src/db/deposits.ts
@@ -42,12 +42,12 @@ export class DepositsDAO {
     try {
       return await prisma.deposit.findUnique({
         where: { id },
-        include: { Player: true },
+        include: { Player: { include: { Bonus: true } } },
       });
     } catch (error) {
       throw error;
     } finally {
-      prisma.$disconnect();
+      // prisma.$disconnect();
     }
   }
 

--- a/src/helpers/useTransaction.ts
+++ b/src/helpers/useTransaction.ts
@@ -1,0 +1,26 @@
+import { PrismaClient } from "@prisma/client";
+import { TransactionCallback } from "@/types/helpers/useTransaction";
+
+export async function useTransaction<T>(
+  cb: TransactionCallback<T>,
+): Promise<T | undefined> {
+  const prisma = new PrismaClient();
+  const MAX_RETRIES = 3;
+  let retries = 0;
+
+  while (retries < MAX_RETRIES) {
+    try {
+      return await prisma.$transaction(async (tx) => cb(tx));
+    } catch (e: any) {
+      if (e.code === "P2034") {
+        retries++;
+        continue;
+      }
+      throw e;
+    } finally {
+      prisma.$disconnect();
+    }
+  }
+
+  return;
+}

--- a/src/middlewares/rate-limiters/bonus.ts
+++ b/src/middlewares/rate-limiters/bonus.ts
@@ -1,0 +1,23 @@
+import { RateLimiterMemory } from "rate-limiter-flexible";
+import CONFIG, { ENVIRONMENTS } from "@/config";
+import { ERR } from "@/config/errors";
+import { CustomError } from "@/helpers/error/CustomError";
+
+const rateLimiter = new RateLimiterMemory({
+  points: CONFIG.APP.ENV === ENVIRONMENTS.TEST ? 10 : 1,
+  duration: 10,
+});
+
+/**
+ * Limit the amount of requests with the same bonus ID to 1 every
+ * 10 seconds
+ */
+export const bonusRateLimiter = (req: Req, res: Res, next: NextFn) => {
+  rateLimiter
+    .consume(req.params.id, 1)
+    .then(() => next())
+    .catch((err): void => {
+      res.header("Retry-After", `${err.msBeforeNext / 1000}`);
+      next(new CustomError(ERR.TOO_MANY_REQUESTS));
+    });
+};

--- a/src/routes/bonus.router.ts
+++ b/src/routes/bonus.router.ts
@@ -14,6 +14,7 @@ import {
   validateBonusCreateRequest,
   validateBonusId,
 } from "@/components/bonus/validators";
+import { bonusRateLimiter } from "@/middlewares/rate-limiters/bonus";
 
 const bonusRouter = Router();
 
@@ -42,6 +43,7 @@ bonusRouter.get(
   validateBonusId(),
   checkExact(),
   throwIfBadRequest,
+  bonusRateLimiter,
   BonusController.redeem,
 );
 bonusRouter.post(

--- a/src/types/helpers/useTransaction.ts
+++ b/src/types/helpers/useTransaction.ts
@@ -1,0 +1,3 @@
+export type TransactionCallback<T> = (
+  tx: PrismaTransactionClient,
+) => Promise<T | undefined>;


### PR DESCRIPTION
Agregué un rate limiter al endpoint `/bonus/:id/redeem`. Solo se puede mandar una solicitud cada 10 segundos para el mismo `:id`.

Cuando los rate limiters alcanzan su máximo de pedidos devuelven
```ts
{
    status: 429,
    code: "too_many_requests",
    description: "Demasiadas solicitudes",
}
```
Y en el encabezado `Retry-After` el número de segundos que se debe esperar para volver a hacer un pedido.